### PR TITLE
Use logging in a few places where it makes sense

### DIFF
--- a/testflinger_cli/__init__.py
+++ b/testflinger_cli/__init__.py
@@ -21,6 +21,7 @@ TestflingerCli module
 
 import inspect
 import json
+import logging
 import os
 import sys
 import time
@@ -30,6 +31,7 @@ import yaml
 
 from testflinger_cli import client, config, history
 
+logger = logging.getLogger(__name__)
 
 # Make it easier to run from a checkout
 basedir = os.path.abspath(os.path.join(__file__, ".."))
@@ -41,9 +43,21 @@ def cli():
     """Generate the TestflingerCli instance and run it"""
     try:
         tfcli = TestflingerCli()
+        configure_logging()
         tfcli.run()
     except KeyboardInterrupt as exc:
         raise SystemExit from exc
+
+
+def configure_logging():
+    """Configure default logging"""
+    logging.basicConfig(
+        level=logging.WARNING,
+        format=(
+            "%(levelname)s: %(asctime)s %(filename)s:%(lineno)d -- %(message)s"
+        ),
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
 
 
 def _get_image(images):
@@ -531,7 +545,7 @@ class TestflingerCli:
         try:
             queues = self.client.get_queues()
         except OSError:
-            print("WARNING: unable to get a list of queues from the server!")
+            logger.warning("Unable to get a list of queues from the server!")
             queues = {}
         queue = self.args.queue or self._get_queue(queues)
         if queue not in queues.keys():
@@ -542,7 +556,7 @@ class TestflingerCli:
         try:
             images = self.client.get_images(queue)
         except OSError:
-            print("WARNING: unable to get a list of images from the server!")
+            logger.warning("Unable to get a list of images from the server!")
             images = {}
         image = self.args.image or _get_image(images)
         if (

--- a/testflinger_cli/client.py
+++ b/testflinger_cli/client.py
@@ -19,10 +19,14 @@ Testflinger client module
 """
 
 import json
+import logging
 import sys
 import urllib.parse
 import requests
 import yaml
+
+
+logger = logging.getLogger(__name__)
 
 
 class HTTPError(Exception):
@@ -50,10 +54,12 @@ class Client:
         try:
             req = requests.get(uri, timeout=timeout)
         except requests.exceptions.ConnectTimeout:
-            print("Timeout while trying to communicate with the server.")
+            logger.error(
+                "Timeout while trying to communicate with the server."
+            )
             raise
         except requests.exceptions.ConnectionError:
-            print("Unable to communicate with specified server.")
+            logger.error("Unable to communicate with specified server.")
             raise
         if req.status_code != 200:
             raise HTTPError(req.status_code)
@@ -70,10 +76,10 @@ class Client:
         try:
             req = requests.post(uri, json=data, timeout=timeout)
         except requests.exceptions.ConnectTimeout:
-            print("Timout while trying to communicate with the server.")
+            logger.error("Timout while trying to communicate with the server.")
             sys.exit(1)
         except requests.exceptions.ConnectionError:
-            print("Unable to communicate with specified server.")
+            logger.error("Unable to communicate with specified server.")
             sys.exit(1)
         if req.status_code != 200:
             raise HTTPError(req.status_code)

--- a/testflinger_cli/history.py
+++ b/testflinger_cli/history.py
@@ -19,10 +19,14 @@ Testflinger history module
 """
 
 import json
+import logging
 import os
 from collections import OrderedDict
 from datetime import datetime
 import xdg
+
+
+logger = logging.getLogger(__name__)
 
 
 class TestflingerCliHistory:
@@ -58,7 +62,9 @@ class TestflingerCliHistory:
                     self.history.update(json.load(history_file))
                 except (OSError, ValueError):
                     # If there's any error loading the history, ignore it
-                    print("Error loading history file from", self.historyfile)
+                    logger.error(
+                        "Error loading history file from %s", self.historyfile
+                    )
 
     def save(self):
         """Save the history out to the history file"""


### PR DESCRIPTION
A lot of our output uses print because it's directed at the user, but there are a few places where it makes more sense to use logging, and has the added benefit of letting us give more details and direct it to stderr so that it doesn't end up in an env var that's only expecting to receive a job_id to stdout.