### PR TITLE
Retry more persistently if timeouts or connection errors occur

### DIFF
--- a/testflinger_cli/__init__.py
+++ b/testflinger_cli/__init__.py
@@ -468,15 +468,15 @@ class TestflingerCli:
                 output = ""
                 try:
                     output = self.get_latest_output(job_id)
+                    if output:
+                        print(output, end="", flush=True)
+                    job_state = self.get_job_state(job_id)
+                    self.history.update(job_id, job_state)
                 except IOError:
                     # Any kind of IOError here should be a connection issue or
                     # a timeout so we should ignore it and retry on the next
                     # pass through the loop
                     continue
-                if output:
-                    print(output, end="", flush=True)
-                job_state = self.get_job_state(job_id)
-                self.history.update(job_id, job_state)
             except KeyboardInterrupt:
                 choice = input(
                     "\nCancel job {} before exiting "
@@ -658,4 +658,6 @@ class TestflingerCli:
                     "Received 404 error from server. Are you "
                     "sure this is a testflinger server?"
                 ) from exc
+        except IOError:
+            logger.warning("Unable to retrieve job state.")
         return "unknown"

--- a/testflinger_cli/__init__.py
+++ b/testflinger_cli/__init__.py
@@ -456,27 +456,20 @@ class TestflingerCli:
                 break
             try:
                 if job_state == "waiting":
-                    try:
-                        queue_pos = self.client.get_job_position(job_id)
-                        if int(queue_pos) != prev_queue_pos:
-                            prev_queue_pos = int(queue_pos)
-                            print("Jobs ahead in queue: {}".format(queue_pos))
-                    except (IOError, client.HTTPError):
-                        # Ignore/retry any connection errors or timeouts
-                        pass
+                    queue_pos = self.client.get_job_position(job_id)
+                    if int(queue_pos) != prev_queue_pos:
+                        prev_queue_pos = int(queue_pos)
+                        print("Jobs ahead in queue: {}".format(queue_pos))
                 time.sleep(10)
                 output = ""
-                try:
-                    output = self.get_latest_output(job_id)
-                    if output:
-                        print(output, end="", flush=True)
-                    job_state = self.get_job_state(job_id)
-                    self.history.update(job_id, job_state)
-                except IOError:
-                    # Any kind of IOError here should be a connection issue or
-                    # a timeout so we should ignore it and retry on the next
-                    # pass through the loop
-                    continue
+                output = self.get_latest_output(job_id)
+                if output:
+                    print(output, end="", flush=True)
+                job_state = self.get_job_state(job_id)
+                self.history.update(job_id, job_state)
+            except (IOError, client.HTTPError):
+                # Ignore/retry any connection errors or timeouts
+                pass
             except KeyboardInterrupt:
                 choice = input(
                     "\nCancel job {} before exiting "

--- a/testflinger_cli/client.py
+++ b/testflinger_cli/client.py
@@ -53,13 +53,14 @@ class Client:
         uri = urllib.parse.urljoin(self.server, uri_frag)
         try:
             req = requests.get(uri, timeout=timeout)
-        except requests.exceptions.ConnectTimeout:
+        except requests.exceptions.ConnectionError:
+            logger.error("Unable to communicate with specified server.")
+            raise
+        except IOError:
+            # This should catch all other timeout cases
             logger.error(
                 "Timeout while trying to communicate with the server."
             )
-            raise
-        except requests.exceptions.ConnectionError:
-            logger.error("Unable to communicate with specified server.")
             raise
         if req.status_code != 200:
             raise HTTPError(req.status_code)


### PR DESCRIPTION
We've had some times where it seems to timeout or get a connection error while polling. This will make it less likely to fail out of the cli if that happens, so that we don't stop running the job prematurely.