### PR TITLE
Fix a few use-dict-literal warnings from pylint

### DIFF
--- a/testflinger_cli/client.py
+++ b/testflinger_cli/client.py
@@ -109,7 +109,7 @@ class Client:
             Job state to set for the specified job
         """
         endpoint = "/v1/result/{}".format(job_id)
-        data = dict(job_state=state)
+        data = {"job_state": state}
         self.put(endpoint, data)
 
     def submit_job(self, job_data):

--- a/testflinger_cli/history.py
+++ b/testflinger_cli/history.py
@@ -42,9 +42,12 @@ class TestflingerCliHistory:
     def new(self, job_id, queue):
         """Add a new job to the history"""
         submission_time = datetime.now().timestamp()
-        self.history[job_id] = dict(
-            queue=queue, submission_time=submission_time, job_state="unknown"
-        )
+        self.history[job_id] = {
+            "queue": queue,
+            "submission_time": submission_time,
+            "job_state": "unknown",
+        }
+
         # limit job history to last 10 jobs
         if len(self.history) > 10:
             self.history.popitem(last=False)


### PR DESCRIPTION
quick fix for some minor pylint warnings that didn't show up in older versions I guess