### PR TITLE
Tell the server not to decode gzipped artifact downloads

### DIFF
--- a/testflinger_cli/client.py
+++ b/testflinger_cli/client.py
@@ -157,12 +157,13 @@ class Client:
         """
         endpoint = "/v1/result/{}/artifact".format(job_id)
         uri = urllib.parse.urljoin(self.server, endpoint)
-        req = requests.get(uri, timeout=15)
+        req = requests.get(uri, timeout=15, stream=True)
         if req.status_code != 200:
             raise HTTPError(req.status_code)
         with open(path, "wb") as artifact:
-            for chunk in req.iter_content(chunk_size=4096):
-                artifact.write(chunk)
+            for chunk in req.raw.stream(4096, decode_content=False):
+                if chunk:
+                    artifact.write(chunk)
 
     def get_output(self, job_id):
         """Get the latest output for a specified test job


### PR DESCRIPTION
It looks like this is a result of a "fix" that went into flask a long time ago, but our previous server was running under an older version of flask that already didn't decode downloads. When using send_file() flask will now decode the gzipped file by default unless you force it not to