### PR TITLE
Make noise if there's an unknown error during cancel

### DIFF
--- a/testflinger_cli/__init__.py
+++ b/testflinger_cli/__init__.py
@@ -274,6 +274,7 @@ class TestflingerCli:
                     "Received 404 error from server. Are you "
                     "sure this is a testflinger server?"
                 ) from exc
+            raise
 
     def configure(self):
         """Print or set configuration values"""


### PR DESCRIPTION
Currently, hitting things like 503 just silently ignore the error without letting the user know. I'd rather it be extra noisy instead.